### PR TITLE
Dynamic vertice count

### DIFF
--- a/backend/include/Point.hpp
+++ b/backend/include/Point.hpp
@@ -2,6 +2,7 @@
 
 #include <GLES3/gl3.h>
 #include <math.h>
+#include <iostream>
 
 constexpr size_t PRIMITIVE_RESTART = 4294967295;
 
@@ -34,6 +35,45 @@ public:
         this->x += tx;
         this->y += ty;
     };
+
+	static Point mix(const Point& a, const Point& b, float m) {
+		return Point(
+			a.x * m + b.x * (1.f-m),
+			a.y * m + b.y * (1.f-m)
+		);
+	}
+
+	bool operator==(const Point& oth) const {
+		return x == oth.x && y == oth.y;
+	}
+
+	Point operator-(const Point& rh) const {
+		return Point(x - rh.x, y - rh.y);
+	}
+	Point operator+(const Point& rh) const {
+		return Point(x + rh.x, y + rh.y);
+	}
+
+	float operator*(const Point& rh) const {
+		return x*rh.x + y*rh.y;
+	}
+
+	Point& operator*=(float f) {
+		x *= f;
+		y *= f;
+		return *this;
+	}
+
+	Point& operator/=(float f) {
+		x /= f;
+		y /= f;
+		return *this;
+	}
+
+	friend std::ostream& operator<<(std::ostream& out, const Point& p) {
+		out << "(" << p.x << "," << p.y << ")";
+		return out;
+	}
 
 };
 

--- a/backend/include/Polygon.hpp
+++ b/backend/include/Polygon.hpp
@@ -12,7 +12,14 @@
 class Polygon
 {
 private:
-    std::vector<Point> vertices; ///<List representation of the polygon.
+	static constexpr float VERTEX_DISTANCE = 0.01f;
+	static constexpr float MAX_DISTANCE2 = VERTEX_DISTANCE * VERTEX_DISTANCE;
+	static constexpr float MIN_DISTANCE2 = MAX_DISTANCE2 * 0.5f;
+	struct Data {
+		Point pos;
+		int insertion; ///< >0 -> insert after this vertex x, <0 remove this
+	};
+    std::vector<Data> vertices; ///<List representation of the polygon.
 
     GLuint colorIndex; ///< Index of a color inside a palette. Exchanging the active palette will change the drawing color.
     
@@ -45,6 +52,10 @@ private:
     */
     static size_t circleVertCount(float radius);
     
+	/** calculate how many points should be inserted between two
+	 * adjanticive points
+	 */
+	static int calcInsertion(const Point& start, const Point& end);
 
 public:
 

--- a/backend/include/Polygon.hpp
+++ b/backend/include/Polygon.hpp
@@ -12,9 +12,9 @@
 class Polygon
 {
 private:
-	static constexpr float VERTEX_DISTANCE = 0.01f;
-	static constexpr float MAX_DISTANCE2 = VERTEX_DISTANCE * VERTEX_DISTANCE;
-	static constexpr float MIN_DISTANCE2 = MAX_DISTANCE2 * 0.5f;
+	static constexpr float VERTEX_DISTANCE = 0.01f; ///< largest distance between vertices -> insertion when distance ist greater
+	static constexpr float MAX_DISTANCE2 = VERTEX_DISTANCE * VERTEX_DISTANCE; // squared for easier useage
+	static constexpr float MIN_DISTANCE2 = MAX_DISTANCE2 * 0.5f; ///< minimal distance -> collapsion when distance is smaller
 	struct Data {
 		Point pos;
 		int insertion; ///< >0 -> insert after this vertex x, <0 remove this

--- a/backend/include/Scene.hpp
+++ b/backend/include/Scene.hpp
@@ -108,16 +108,17 @@ public:
 
 	// stores current state, advance generation
 	void applyDisplacement() {
-		int count = 0;
 		for(auto& p : *this) {
-			std::cerr << count++ << ": ";
 			p.displace(displacement.p, displacement.r);
 		}
+
+		// remove polygons with less then 3 vertices
 		polygons.erase(
 			std::remove_if(begin(), end(), [](const Polygon& p){
 				return p.getVertCount() < 3;
 			}),
 			end());
+
 		displacement.r = 0;
 		++generation;
 	}

--- a/backend/include/Scene.hpp
+++ b/backend/include/Scene.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <algorithm>
 
 #include "Polygon.hpp"
 
@@ -35,6 +36,7 @@ public:
     int addPolygon(Polygon const &pol)
     {
         polygons.push_back(pol);
+		++generation;
         return polygons.size() - 1;
     }
 
@@ -106,9 +108,16 @@ public:
 
 	// stores current state, advance generation
 	void applyDisplacement() {
+		int count = 0;
 		for(auto& p : *this) {
+			std::cerr << count++ << ": ";
 			p.displace(displacement.p, displacement.r);
 		}
+		polygons.erase(
+			std::remove_if(begin(), end(), [](const Polygon& p){
+				return p.getVertCount() < 3;
+			}),
+			end());
 		displacement.r = 0;
 		++generation;
 	}

--- a/backend/src/Polygon.cpp
+++ b/backend/src/Polygon.cpp
@@ -91,7 +91,6 @@ int Polygon::calcInsertion(const Point& start, const Point& end) {
 void Polygon::displace(Point c, float r)
 {
 	assert(vertices.size() > 2);
-	std::cerr << "from: " << vertices.size();
     isCircle = false;
 	displacePoint(vertices[0].pos, c, r);
 	int size_diff = 0;
@@ -108,6 +107,8 @@ void Polygon::displace(Point c, float r)
 	vertices[0].insertion
 		= calcInsertion(vertices.back().pos, vertices[0].pos);
 	size_diff += vertices[0].insertion;
+
+	// remove collapsed vertices
 	int del = 0;
 	{
 		auto dst = vertices.begin();
@@ -120,6 +121,8 @@ void Polygon::displace(Point c, float r)
 		}
 		del = src - dst;
 	}
+
+	// insert new vertices
 	if(size_diff > 0) { vertices.resize(vertices.size() + size_diff); }
 	auto dst = vertices.rbegin() + std::max(0, -size_diff);
 	auto src = vertices.rbegin() + del + std::max(0, size_diff);
@@ -150,7 +153,6 @@ void Polygon::displace(Point c, float r)
 		assert(src >= dst);
 	}
 	if(size_diff < 0) { vertices.resize(vertices.size() + size_diff);}
-	std::cerr << "\tto: " << vertices.size() << std::endl;
 }
 
 void Polygon::makeCircle(Point mid, float radius)

--- a/backend/src/Polygon.cpp
+++ b/backend/src/Polygon.cpp
@@ -1,5 +1,7 @@
 #include "Polygon.hpp"
 
+#include <cassert>
+
 Polygon::Polygon(Point mid, float radius, GLuint colorIndex): colorIndex{colorIndex}, isCircle{true}, creationPoint{mid}
 {
     makeCircle(mid, radius);
@@ -17,7 +19,7 @@ void Polygon::getDrawInfo(std::vector<WGLVertex>& vertices, GLuint z) const
 {
 	vertices.resize(this->vertices.size());
 	for(size_t i = 0; i < this->vertices.size(); ++i) {
-		vertices[i] = WGLVertex{this->vertices[i], z, colorIndex};
+		vertices[i] = WGLVertex{this->vertices[i].pos, z, colorIndex};
 	}
 }
 
@@ -36,18 +38,119 @@ size_t Polygon::circleVertCount(float radius)
     return vert_count;
 }
 
+/** displace a point in place
+ */
+Point& displacePoint(Point& p, const Point& c, float r) {
+	Point d = p - c;
+	d *= sqrtf(1 + r*r/ (d*d) );
+	p = c + d;
+	return p;
+}
+
+Point displacePoint(const Point& p, const Point& c, float r) {
+	Point ret(p);
+	return displacePoint(ret, c, r);
+}
+
+// p = c + d
+// p2 = c + d2
+// p2 = c + d*s
+// d2 = d * s
+// d = d2/s
+// s = sqrt(1+r*r/<d,d>)
+// s^2 = 1 + r^2 / <d2/s,d2/s>
+// s^2 = 1 + r^2 * s^2 / <d2,d2>
+// 1 = 1/s^2 + r^2/<d2,d2>
+// 1/s^2 = 1 - r^2/<d2,d2>
+// 1/(1-r^2/<d2,d2>) = s^2
+// s = sqrt(1/(1-r^2/<d2,d2>))
+// d = d2 * 1/s
+Point reverseDisplacementPoint(const Point& p, const Point& c, float r) {
+	Point d = p - c;
+	float det = 1.f - r*r/(d*d);
+	if(det <= 0.f) {
+		d /= sqrtf(d*d);
+		d *= Polygon::MIN_R;
+	} else {
+		d /= sqrtf(1.f/(1.f-r*r/(d*d)));
+	}
+	return c + d;
+}
+
+int Polygon::calcInsertion(const Point& start, const Point& end) {
+		float d2 = distance2(start, end);
+		if(d2 > MAX_DISTANCE2) {
+			return static_cast<int>(
+					ceilf(sqrtf(d2) / VERTEX_DISTANCE));
+		} else if (d2 < MIN_DISTANCE2) {
+			return -1;
+		}
+		return 0;
+}
+
 void Polygon::displace(Point c, float r)
 {
+	assert(vertices.size() > 2);
+	std::cerr << "from: " << vertices.size();
     isCircle = false;
-	for(auto& p : vertices) {
-		float dx = p.x - c.x;
-		float dy = p.y - c.y;
-		float s = sqrtf(1 + r*r/(dx*dx + dy*dy));
-		dx *= s;
-		dy *= s;
-		p.x = c.x + dx;
-		p.y = c.y + dy;
-	}	
+	displacePoint(vertices[0].pos, c, r);
+	int size_diff = 0;
+	size_t lastId = 0;
+	for(std::size_t i = 1; i < vertices.size(); ++i) {
+		Point& p = vertices[i].pos;
+		Point copy = p;
+		displacePoint(p, c, r);
+		vertices[i].insertion = calcInsertion(vertices[lastId].pos, p);
+
+		if (vertices[i].insertion >= 0) {lastId = i; }
+		size_diff += vertices[i].insertion;
+	}
+	vertices[0].insertion
+		= calcInsertion(vertices.back().pos, vertices[0].pos);
+	size_diff += vertices[0].insertion;
+	int del = 0;
+	{
+		auto dst = vertices.begin();
+		decltype(vertices)::iterator src;
+		for(src = vertices.begin(); src != vertices.end(); ++src) {
+			if (src->insertion >= 0) {
+				*dst = *src;
+				++dst;
+			}
+		}
+		del = src - dst;
+	}
+	if(size_diff > 0) { vertices.resize(vertices.size() + size_diff); }
+	auto dst = vertices.rbegin() + std::max(0, -size_diff);
+	auto src = vertices.rbegin() + del + std::max(0, size_diff);
+	int insertion = 0;
+	float fraction = 0.f;
+	Point last{};
+	Point next{};
+	while(dst != vertices.rend()) {
+		if(insertion) {
+			float x = fraction * insertion;
+			dst->pos = displacePoint(Point::mix(last, next, x), c, r);
+			++dst;
+			--insertion;
+		} else if(src->insertion >= 0) {
+			assert(src != vertices.rend());
+			*dst = *src;
+			insertion = src->insertion;
+			fraction = 1.f / static_cast<float>(insertion+1);
+			last = reverseDisplacementPoint(src->pos, c, r);
+			++dst;
+			++src;
+			next = src != vertices.rend()
+				? reverseDisplacementPoint(src->pos, c, r)
+				: reverseDisplacementPoint(vertices.back().pos, c, r);
+		} else {
+			++src;
+		}
+		assert(src >= dst);
+	}
+	if(size_diff < 0) { vertices.resize(vertices.size() + size_diff);}
+	std::cerr << "\tto: " << vertices.size() << std::endl;
 }
 
 void Polygon::makeCircle(Point mid, float radius)
@@ -59,7 +162,7 @@ void Polygon::makeCircle(Point mid, float radius)
         for (int i = 0; i < count; ++i)
         {
             float angle = (float)i / (float)count * 2 * M_PI;
-            vertices[i] = Point(radius * cosf(angle) + mid.x, radius * sinf(angle) + mid.y);
+            vertices[i] = {Point(radius * cosf(angle) + mid.x, radius * sinf(angle) + mid.y), 0};
         }
     }
     else

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -89,12 +89,9 @@ extern "C"
 		uint8_t c[4];
 		glReadPixels((x+1.f)*720/2, (y+1.f)*720/2, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, c);
 		const auto& [cr,cg,cb] = (*Options::getInstance()->getActivePalette())[color].getRGB();
-		std::cout << "target: "<< (int)cr << ", " << (int)cg << ", " << (int)cb << std::endl;
-		std::cout << "\t" << (int)c[0] << ", " << (int)c[1] << ", " << (int)c[2] << std::endl;
 		if(cr == c[0] && cg == c[1] && cb == c[2]) {
 			return -1;
 		}
-		std::cerr << "new polygone\n";
         int handle = scene->addPolygon(Polygon{Point{x,y}, Polygon::MIN_R, color});
         return handle;
     }

--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -84,15 +84,18 @@ extern "C"
         r = r>=Polygon::MIN_R ? r : Polygon::MIN_R;
 		scene->setDisplacement({x,y}, r);
 
-		/*uint8_t c[4]; more poost
-		glReadPixels((x+1.f)*720/2, (1.f-y)*720/2, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, c);
+        sceneRenderer->drawScene(*scene);
+
+		uint8_t c[4];
+		glReadPixels((x+1.f)*720/2, (y+1.f)*720/2, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, c);
 		const auto& [cr,cg,cb] = (*Options::getInstance()->getActivePalette())[color].getRGB();
+		std::cout << "target: "<< (int)cr << ", " << (int)cg << ", " << (int)cb << std::endl;
+		std::cout << "\t" << (int)c[0] << ", " << (int)c[1] << ", " << (int)c[2] << std::endl;
 		if(cr == c[0] && cg == c[1] && cb == c[2]) {
 			return -1;
 		}
-		std::cerr << "new polygone\n";*/
+		std::cerr << "new polygone\n";
         int handle = scene->addPolygon(Polygon{Point{x,y}, Polygon::MIN_R, color});
-        sceneRenderer->drawScene(*scene);
         return handle;
     }
 


### PR DESCRIPTION
Dynamic vertices count (parameters in `Polygon.hpp`)
* insert new vertices between vertices when distance get too large
* collapse vertices which are to close to each other

don't create polygons with same color on top of each other → keeps polygon
count small

Delete polygons with less than 2 vertices because there are literally points,
and can't expand anymore.

close #67 
