### PR TITLE
Add caching for emsdk in Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - feature#69/switch_pages
+      - feature/#55-ghpages-cache-dependencies
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -19,13 +19,11 @@ jobs:
         uses: mymindstorm/setup-emsdk@v9
         with:
           version: 2.0.16
+          actions-cache-folder: emsdk-cache
 
       #Following two just for info in case something goes wrong
       - name: Verify
         run: emcc -v
-
-      - name: Tree
-        run: tree
 
       - name: Run emCMake
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - feature/#55-ghpages-cache-dependencies
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #55 

[According to this guide](https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#comparing-artifacts-and-dependency-caching) Github Artifacts wouldn't actually have been the right thing to use, since it's main purpose is to make data available for download after the workflow is finished.