### PR TITLE
normalized rake input ||(x,y)|| == speed

### DIFF
--- a/backend/src/main.cpp
+++ b/backend/src/main.cpp
@@ -173,13 +173,14 @@ extern "C"
 		sceneRenderer->drawScene(*scene);
 	}
 
-	/** execute a linear rake in direction <x,y> with speed <speed>. 
+	/** execute a linear rake in direction <x,y> with speed = ||<x,y>||. 
     * <nails> is an array of bool with are the nails from begin to end of the rake. a 1 means there is a nail, 0 means thar is not.
     */
-	void EMSCRIPTEN_KEEPALIVE rakeLinear(float x, float y, float speed, bool nails[1000]) {
+	void EMSCRIPTEN_KEEPALIVE rakeLinear(float x, float y, bool nails[1000]) {
 
 		// TODO: implement 
-		std::cerr << "Rake: dir(" << x << ", " << y << ") with " << speed << "\n";
+		float len = sqrt(x*x+y*y);
+		std::cerr << "Rake: dir(" << x/len << ", " << y/len << ") with " << len << "\n";
 		GLuint nail_uint[1000];
 		for(int i = 0; i < 1000; ++i) { nail_uint[i] = nails[i] ? 1 : 0; }
 		int count = 0;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -88,7 +88,7 @@ window.Module = {
 			'void', []);
 		backend.startRaking = Module.cwrap('startRaking', 'void', [])
 		backend.rakeLinear = Module.cwrap('rakeLinear',
-			'boolean', ['number', 'number', 'number', 'array'])
+			'boolean', ['number', 'number', 'array'])
 		backend.finishDrop = Module.cwrap('finishDrop', 'number', ['number'])
 		backend.clearCanvas = Module.cwrap('clearCanvas', 'void', [])
 		backend.fn_bind = true;
@@ -809,7 +809,7 @@ var rake = {
 		} else {
 			handle = Math.floor(start.x / w * 1000.)
 		}
-		backend.rakeLinear(d.x/w, d.y/h, len,rake.config.placement.getNails(handle))
+		backend.rakeLinear(d.x/w, d.y/h, rake.config.placement.getNails(handle))
 	}
 };
 // snap line parallel to axisa

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -696,13 +696,6 @@ var rake = {
 		ctx.lineWidth = 2;
 		ctx.strokeStyle = 'black';
 		ctx.fillStyle = 'black';
-		const d = {x: end.x - start.x, y: end.y - start.y};
-		console.log(d)
-		const len = Math.sqrt((d.x / w * rake.scale)**2 + (d.y / h * rake.scale)**2);
-		if( len > 1) {
-			end.x = start.x + d.x / len;
-			end.y = start.y + d.y / len;
-		}
 		drawArrow(ctx, start, end, 10);
 	},
 	curve: function(ctx, start, end, w, h) {
@@ -803,10 +796,12 @@ var rake = {
 		ctx.setTransform(1,0,0,1,0,0);
 
 		ctx.strokeStyle = 'black';
+		clamp(start,end,w,h,rake.scale)
 		rake.config.line(ctx, start,end, w, h);
 	},
 	up: function(start, end, w, h) {
 		if(!start || !end) { return}
+		clamp(start, end, w,h, rake.scale)
 		const d = {x: end.x - start.x, y: end.y - start.y} 
 		const up = {x: -d.y, y: d.x};
 		var handle = 0;
@@ -816,7 +811,7 @@ var rake = {
 		} else {
 			handle = Math.floor(start.x / w * 1000.)
 		}
-		backend.rakeLinear(d.x/(w*rake.scale), d.y/(h*rake.scale), rake.config.placement.getNails(handle))
+		backend.rakeLinear(d.x/w*rake.scale, d.y/h*rake.scale, rake.config.placement.getNails(handle))
 	}
 };
 // snap line parallel to axisa
@@ -828,6 +823,16 @@ function snap(start,end) {
 		a.x = 0;
 	}
 	return [start, {x: start.x + a.x, y: start.y + a.y}];
+}
+
+// clamp end to ||(end-start)/dim*scale|| <= 1
+function clamp(start,end,w,h,scale) {
+		const d = {x: end.x - start.x, y: end.y - start.y};
+		const len = Math.sqrt((d.x / w * scale)**2 + (d.y / h * scale)**2);
+		if( len > 1) {
+			end.x = start.x + d.x / len;
+			end.y = start.y + d.y / len;
+		}
 }
 
 var tool = {

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -659,6 +659,7 @@ var rake_dropper = {
 };
 
 var rake = {
+	scale: 2.,
 	borderPoint: function(a, m, w, h, x) {
 		const y = a + m * x;
 		if(y < 0) {
@@ -695,6 +696,13 @@ var rake = {
 		ctx.lineWidth = 2;
 		ctx.strokeStyle = 'black';
 		ctx.fillStyle = 'black';
+		const d = {x: end.x - start.x, y: end.y - start.y};
+		console.log(d)
+		const len = Math.sqrt((d.x / w * rake.scale)**2 + (d.y / h * rake.scale)**2);
+		if( len > 1) {
+			end.x = start.x + d.x / len;
+			end.y = start.y + d.y / len;
+		}
 		drawArrow(ctx, start, end, 10);
 	},
 	curve: function(ctx, start, end, w, h) {
@@ -800,7 +808,6 @@ var rake = {
 	up: function(start, end, w, h) {
 		if(!start || !end) { return}
 		const d = {x: end.x - start.x, y: end.y - start.y} 
-		const len =  Math.sqrt(d.x*d.x+d.y*d.y)
 		const up = {x: -d.y, y: d.x};
 		var handle = 0;
 		// TODO: adopt for free form rakes!
@@ -809,7 +816,7 @@ var rake = {
 		} else {
 			handle = Math.floor(start.x / w * 1000.)
 		}
-		backend.rakeLinear(d.x/w, d.y/h, rake.config.placement.getNails(handle))
+		backend.rakeLinear(d.x/(w*rake.scale), d.y/(h*rake.scale), rake.config.placement.getNails(handle))
 	}
 };
 // snap line parallel to axisa


### PR DESCRIPTION
* Clamp length of tooltip to 1/2 canvas -> easier full speed strokes
* changed lineareRake function: remved speed parameter, now implicit in x and y
